### PR TITLE
Added numbers for Belgian and Swiss French speakers

### DIFF
--- a/mathparse/mathwords.py
+++ b/mathparse/mathwords.py
@@ -97,8 +97,11 @@ MATH_WORDS = {
             'cinquante': 50,
             'soixante': 60,
             'soixante-dix': 70,
+            'septante': 70,
             'quatre-vingts': 80,
-            'quatre-vingt-dix': 90
+            'huitante': 80,
+            'quatre-vingt-dix': 90,
+            'nonante': 90
         },
         'scales': {
             'cent': 100,


### PR DESCRIPTION
This PR adds septante, huitante, and nonante (70, 80, 90) to the list of french numbers