### PR TITLE
Fix for issue #6

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing = True

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+#IDEA settings
+.idea/

--- a/mathparse/mathparse.py
+++ b/mathparse/mathparse.py
@@ -193,7 +193,10 @@ def evaluate_postfix(tokens):
             elif token == '^':
                 total = a ** b
             elif token == '/':
-                total = Decimal(str(a)) / Decimal(str(b))
+                if Decimal(str(b)) == 0:
+                    total = 'undefined'
+                else:
+                    total = Decimal(str(a)) / Decimal(str(b))
             else:
                 raise PostfixTokenEvaluationException('Unknown token {}'.format(token))
 

--- a/mathparse/mathwords.py
+++ b/mathparse/mathwords.py
@@ -25,6 +25,7 @@ MATH_WORDS = {
             'to the power of': '^'
         },
         'numbers': {
+            'zero': 0,
             'one': 1,
             'two': 2,
             'three': 3,

--- a/tests/test_binary_operations.py
+++ b/tests/test_binary_operations.py
@@ -49,6 +49,16 @@ class PositiveIntegerTestCase(TestCase):
 
         self.assertEqual(result, 3)
 
+    def test_division_by_zero(self):
+        result = mathparse.parse('42 / 0', language='ENG')
+
+        self.assertEqual(result, 'undefined')
+
+    def test_division_by_zero_words(self):
+        result = mathparse.parse('six divided by zero', language='ENG')
+
+        self.assertEqual(result, 'undefined')
+
 
 class PositiveFloatTestCase(TestCase):
 


### PR DESCRIPTION
I added a check that sees if the divisor is 0. If it is, we return 'undefined'. Otherwise we divide it. Included in this commit is .coveragerc which will now show what lines aren't covered by the unit tests. 