### PR TITLE
Fixed issue #15

### DIFF
--- a/mathparse/mathparse.py
+++ b/mathparse/mathparse.py
@@ -105,11 +105,9 @@ def replace_word_tokens(string, language):
             matches = list(re.finditer(scale, string))
 
             start_index = matches[0].start() - 1
-            end_index = len(string)
 
-            while is_int(string[start_index]) and start_index >= 0:
+            while is_int(string[start_index - 1]) and start_index > 0:
                 start_index -= 1
-            start_index -= 1
 
             end_index = string.find(' ', start_index) + 1
             end_index = string.find(' ', end_index) + 1

--- a/tests/test_binary_operations.py
+++ b/tests/test_binary_operations.py
@@ -49,6 +49,11 @@ class PositiveIntegerTestCase(TestCase):
 
         self.assertEqual(result, 3)
 
+    def test_double_digit_multiplier_for_scale_addition(self):
+        result = mathparse.parse('fifty thousand plus one', language='ENG')
+
+        self.assertEqual(result, 50001)
+
 
 class PositiveFloatTestCase(TestCase):
 

--- a/tests/test_replace_word_tokens.py
+++ b/tests/test_replace_word_tokens.py
@@ -18,3 +18,8 @@ class EnglishWordTokenTestCase(TestCase):
         result = mathparse.replace_word_tokens('five thousand + 30', language='ENG')
 
         self.assertEqual(result, '(5 * 1000) + 30')
+
+    def test_double_digit_multiplier_for_scale(self):
+        result = mathparse.replace_word_tokens('fifty thousand + 1', language='ENG')
+
+        self.assertEqual(result, '(50 * 1000) + 1')


### PR DESCRIPTION
Corrected the issue where `fifty thousand` was being rewrote as `5(0 * 1000)`. Now this will handle multiple digit numbers before a scale number. 