### PR TITLE
Fixing float + Decimal (Type Error) | And allowing math syntax without spaces as input

### DIFF
--- a/mathparse/mathparse.py
+++ b/mathparse/mathparse.py
@@ -177,7 +177,7 @@ def to_postfix(tokens):
         if is_int(token):
             postfix.append(int(token))
         elif is_float(token):
-            postfix.append(float(token))
+            postfix.append(Decimal(token))
         elif token in mathwords.CONSTANTS:
             postfix.append(mathwords.CONSTANTS[token])
         elif is_unary(token):
@@ -294,11 +294,29 @@ def parse(string, language=None):
     return evaluate_postfix(postfix)
 
 
+def insert_spaces(statement_text):
+    """
+    4+2 -> 4 + 2
+    23456.01+(2435.2/523454.324)-(52344^3+5435)^2 ->
+    23456.01 + (2435.2 / 523454.324) - (52344 ^ 3 + 5435) ^ 2
+
+    """
+    s = statement_text
+    f = re.search(r"(\S)([\+\-\*\/\^\*])(\S)", s)
+    if f:
+        s = s.replace(
+            "{}{}{}".format(f[1], f[2], f[3]), "{} {} {}".format(f[1], f[2], f[3])
+        )
+        s = insert_spaces(s)
+    return s
+
+
 def extract_expression(dirty_string, language):
     """
     Give a string such as: "What is 4 + 4?"
     Return the string "4 + 4"
     """
+    dirty_string = insert_spaces(dirty_string)
     tokens = tokenize(dirty_string, language)
 
     start_index = 0

--- a/tests/test_binary_operations.py
+++ b/tests/test_binary_operations.py
@@ -80,7 +80,7 @@ class PositiveFloatTestCase(TestCase):
     def test_addition(self):
         result = mathparse.parse('0.6 + 0.5')
 
-        self.assertEqual(result, 1.1)
+        self.assertEqual(float(result), 1.1)
 
     def test_subtraction(self):
         result = mathparse.parse('30.1 - 29.1')
@@ -90,9 +90,9 @@ class PositiveFloatTestCase(TestCase):
     def test_multiplication(self):
         result = mathparse.parse('0.9 * 0.9')
 
-        self.assertEqual(result, 0.81)
+        self.assertEqual(float(result), 0.81)
 
     def test_division(self):
         result = mathparse.parse('0.6 / 0.2')
 
-        self.assertEqual(result, 3)
+        self.assertEqual(float(result), 3)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -89,3 +89,16 @@ class ExtractExpressionTestCase(TestCase):
         )
 
         self.assertEqual(result, 'three plus three')
+
+    def test_complicated_case(self):
+        _expr = mathparse.extract_expression(
+            "23456.01+(2435.2/523454.324)-(52344^3+5435)^2", "ENG"
+        )
+        result = mathparse.parse(_expr)
+
+        self.assertEqual(float(result), 2.491630792289360313884500230e51322)
+
+    def test_less_complicated_case(self):
+        _expr = mathparse.extract_expression("6 + (2 / 4) - (4 + 5) ^ 2", "ENG")
+        result = mathparse.parse(_expr)
+        self.assertEqual(float(result), 6.25)


### PR DESCRIPTION
Type Error may occur in complicated expression where float get added to Decimal. Treating float as Decimal will fix the issue.

Adding a function to add spaces in expression so `4+2` in statement.text will become valid to be tokenized.

```
# This 
23456.01+(2435.2/523454.324)-(52344^3+5435)^2
# Will be extracted as
23456.01 + (2435.2 / 523454.324) - (52344 ^ 3 + 5435) ^ 2
```

Fixed tests so Decimal and Float be compared correctly (using float...)