### PR TITLE
Fix "squared" unary operator precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ See the full documentation at https://mathparse.chatterbot.us
 
 ## Changelog
 
-See [release notes](https://github.com/gunthercox/ChatterBot/releases) for changes.
+See [release notes](https://github.com/gunthercox/mathparse/releases) for changes.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -55,3 +55,10 @@ You can then open the generated HTML files in the `html/` directory, or serve th
     python -m http.server --directory html 8000
 
 .. _`ISO 639-2`: https://www.loc.gov/standards/iso639-2/php/code_list.php
+
+
+To run the test suite, use unittest:
+
+.. code-block:: shell
+
+    python -m unittest discover tests

--- a/mathparse/mathparse.py
+++ b/mathparse/mathparse.py
@@ -109,18 +109,34 @@ def replace_word_tokens(string: str, language: str) -> str:
     """
     words = mathwords.word_groups_for_language(language)
 
-    # Replace operator words with numeric operators
-    operators = words['binary_operators'].copy()
-    if 'unary_operators' in words:
-        operators.update(words['unary_operators'])
-
-    for operator in list(operators.keys()):
+    # Replace binary operator words with numeric operators
+    binary_operators = words['binary_operators']
+    for operator in frozenset(binary_operators.keys()):
         if operator in string:
-            string = string.replace(operator, operators[operator])
+            string = string.replace(operator, binary_operators[operator])
+
+    # Handle prefix unary operators (like "square root of")
+    if 'prefix_unary_operators' in words:
+        prefix_unary_operators = words['prefix_unary_operators']
+        for operator in frozenset(prefix_unary_operators.keys()):
+            if operator in string:
+                string = string.replace(
+                    operator, prefix_unary_operators[operator]
+                )
+
+    # Handle postfix unary operators (like "squared", "cubed")
+    if 'postfix_unary_operators' in words:
+        postfix_unary_operators = words['postfix_unary_operators']
+        for operator in frozenset(postfix_unary_operators.keys()):
+            if operator in string:
+                # Captures the number/operand before the unary operator
+                pattern = r'(\w+)\s+' + re.escape(operator)
+                replacement = r'(\1 ' + postfix_unary_operators[operator] + ')'
+                string = re.sub(pattern, replacement, string)
 
     # Replace number words with numeric values
     numbers = words['numbers']
-    for number in list(numbers.keys()):
+    for number in frozenset(numbers.keys()):
         if number in string:
             string = string.replace(number, str(numbers[number]))
 
@@ -129,12 +145,12 @@ def replace_word_tokens(string: str, language: str) -> str:
     end_index_characters = mathwords.BINARY_OPERATORS
     end_index_characters.add('(')
 
-    word_matches = find_word_groups(string, list(scales.keys()))
+    word_matches = find_word_groups(string, frozenset(scales.keys()))
 
     for match in word_matches:
         string = string.replace(match, '(' + match + ')')
 
-    for scale in list(scales.keys()):
+    for scale in frozenset(scales.keys()):
         for _ in range(0, string.count(scale)):
             start_index = string.find(scale) - 1
             end_index = len(string)
@@ -173,6 +189,9 @@ def to_postfix(tokens: list) -> list:
         '(': 1
     }
 
+    # Unary functions have a higher precedence than binary operators
+    unary_precedence = max(precedence.values()) + 1
+
     postfix = []
     opstack = []
 
@@ -193,8 +212,19 @@ def to_postfix(tokens: list) -> list:
                 postfix.append(top_token)
                 top_token = opstack.pop()
         else:
+            # For binary operators, pop operators with higher or
+            # equal precedence
             while (opstack != []) and (
-                precedence[opstack[-1]] >= precedence[token]
+                (
+                    opstack[-1] in precedence and token in precedence and (
+                        precedence[opstack[-1]] >= precedence[token]
+                    )
+                ) or
+                (
+                    is_unary(
+                        opstack[-1]
+                    ) and unary_precedence >= precedence[token]
+                )
             ):
                 postfix.append(opstack.pop())
             opstack.append(token)
@@ -238,7 +268,7 @@ def evaluate_postfix(tokens: list) -> Union[int, float, str, Decimal]:
                     total = Decimal(str(a)) / Decimal(str(b))
             else:
                 raise PostfixTokenEvaluationException(
-                    'Unknown token {}'.format(token)
+                    'Unknown token "{}"'.format(token)
                 )
 
         if total is not None:

--- a/mathparse/mathwords.py
+++ b/mathparse/mathwords.py
@@ -466,16 +466,16 @@ def word_groups_for_language(language_code: str) -> dict[str, dict[str, str]]:
     return MATH_WORDS[language_code]
 
 
-def words_for_language(language_code: str) -> list[str]:
+def words_for_language(language_code: str) -> set[str]:
     """
     Return the math words for a language code.
     The language_code should be an ISO 639-2 language code.
     https://www.loc.gov/standards/iso639-2/php/code_list.php
     """
     word_groups = word_groups_for_language(language_code)
-    words = []
+    words = set()
 
     for group in word_groups:
-        words.extend(word_groups[group].keys())
+        words.update(word_groups[group].keys())
 
     return words

--- a/mathparse/mathwords.py
+++ b/mathparse/mathwords.py
@@ -10,10 +10,12 @@ BINARY_OPERATORS = {
 
 MATH_WORDS = {
     'ENG': {
-        'unary_operators': {
+        'prefix_unary_operators': {
+            'square root of': 'sqrt'
+        },
+        'postfix_unary_operators': {
             'squared': '^ 2',
             'cubed': '^ 3',
-            'square root of': 'sqrt'
         },
         'binary_operators': {
             'plus': '+',
@@ -163,10 +165,12 @@ MATH_WORDS = {
         }
     },
     'GRE': {
-        'unary_operators': {
+        'prefix_unary_operators': {
+            'τετραγωνική ρίζα του': 'sqrt'
+        },
+        'postfix_unary_operators': {
             'στο τετράγωνο': '^ 2',
             'στον κύβο': '^ 3',
-            'τετραγωνική ρίζα του': 'sqrt'
         },
         'binary_operators': {
             'συν': '+', 'και': '+',
@@ -367,10 +371,12 @@ MATH_WORDS = {
         }
     },
     'POR': {
-        'unary_operators': {
+        'prefix_unary_operators': {
+            'raiz quadrada de': 'sqrt'
+        },
+        'postfix_unary_operators': {
             'ao quadrado': '^ 2',
             'ao cubo': '^ 3',
-            'raiz quadrada de': 'sqrt'
         },
         'binary_operators': {
             'mais': '+',

--- a/tests/test_complex_statements.py
+++ b/tests/test_complex_statements.py
@@ -10,3 +10,7 @@ class ComplexStatementsTestCase(TestCase):
     def test_numeric_values_with_squared_operator(self):
         result = mathparse.parse('10 plus 2 squared times 3', language='ENG')
         self.assertEqual(result, 10 + 2 ** 2 * 3)
+
+    def test_numeric_values_with_squared_operator(self):
+        result = mathparse.parse('10 plus square root of 4 times 3', language='ENG')
+        self.assertEqual(result, 10 + 2 * 3)

--- a/tests/test_complex_statements.py
+++ b/tests/test_complex_statements.py
@@ -15,6 +15,6 @@ class ComplexStatementsTestCase(TestCase):
 
     def test_numeric_values_with_square_root_operator(self):
         result = mathparse.parse(
-            '10 plus square root of 4 times 3', language='ENG'
+            '10 plus the square root of 4 times 3', language='ENG'
         )
         self.assertEqual(result, 10 + 2 * 3)

--- a/tests/test_complex_statements.py
+++ b/tests/test_complex_statements.py
@@ -8,9 +8,13 @@ class ComplexStatementsTestCase(TestCase):
     """
 
     def test_numeric_values_with_squared_operator(self):
-        result = mathparse.parse('10 plus 2 squared times 3', language='ENG')
+        result = mathparse.parse(
+            '10 plus 2 squared times 3', language='ENG'
+        )
         self.assertEqual(result, 10 + 2 ** 2 * 3)
 
-    def test_numeric_values_with_squared_operator(self):
-        result = mathparse.parse('10 plus square root of 4 times 3', language='ENG')
+    def test_numeric_values_with_square_root_operator(self):
+        result = mathparse.parse(
+            '10 plus square root of 4 times 3', language='ENG'
+        )
         self.assertEqual(result, 10 + 2 * 3)

--- a/tests/test_complex_statements.py
+++ b/tests/test_complex_statements.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+from mathparse import mathparse
+
+
+class ComplexStatementsTestCase(TestCase):
+    """
+    Test cases for complex mathematical expressions.
+    """
+
+    def test_numeric_values_with_squared_operator(self):
+        result = mathparse.parse('10 plus 2 squared times 3', language='ENG')
+        self.assertEqual(result, 10 + 2 ** 2 * 3)

--- a/tests/test_replace_word_tokens.py
+++ b/tests/test_replace_word_tokens.py
@@ -31,3 +31,9 @@ class EnglishWordTokenTestCase(TestCase):
         )
 
         self.assertEqual(result, '((50 * 1000)) + 1')
+
+    def test_numeric_values_with_squared_operator(self):
+        result = mathparse.replace_word_tokens(
+            '10 plus 2 squared times 3', language='ENG'
+        )
+        self.assertEqual(result, '10 + (2 ^ 2) * 3')

--- a/tests/test_replace_word_tokens.py
+++ b/tests/test_replace_word_tokens.py
@@ -40,6 +40,6 @@ class EnglishWordTokenTestCase(TestCase):
 
     def test_numeric_values_with_squared_unary_operator(self):
         result = mathparse.replace_word_tokens(
-            '10 plus square root of 2 times 3', language='ENG'
+            '10 plus the square root of 2 times 3', language='ENG'
         )
         self.assertEqual(result, '10 + sqrt 2 * 3')

--- a/tests/test_replace_word_tokens.py
+++ b/tests/test_replace_word_tokens.py
@@ -32,8 +32,14 @@ class EnglishWordTokenTestCase(TestCase):
 
         self.assertEqual(result, '((50 * 1000)) + 1')
 
-    def test_numeric_values_with_squared_operator(self):
+    def test_numeric_values_with_squared_word_operator(self):
         result = mathparse.replace_word_tokens(
             '10 plus 2 squared times 3', language='ENG'
         )
         self.assertEqual(result, '10 + (2 ^ 2) * 3')
+
+    def test_numeric_values_with_squared_unary_operator(self):
+        result = mathparse.replace_word_tokens(
+            '10 plus square root of 2 times 3', language='ENG'
+        )
+        self.assertEqual(result, '10 + sqrt 2 * 3')


### PR DESCRIPTION
This splits prefix and postfix unary operators into two separate categories so they can be processed with the correct precedence.

Examples:
* `square root of` is prefixed as `sqrt(n)`
* `squred` is postfixed as `(n ^ 2)`

Closes #29

***

This also includes a change to ignore unregistered words when tokenizing strings so stopwords can be ignored in inputs such as "five times *the* square root of 4".

Closes https://github.com/gunthercox/ChatterBot/issues/2041
